### PR TITLE
Linode support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chrisroberts.code@gmail.com'
 license 'Apache 2.0'
 description 'Create DNS entries for nodes'
 
-version '0.1.3'
+version '0.1.4'
 
 depends 'hosts_file', '~> 0.1.4'
 depends 'build-essential', '>= 1.1.0' # set minimum so we get compile time support

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -50,8 +50,6 @@ end
 
 def connection
   @con ||= CookbookDNS.fog(
-    Mash.new(:provider => new_resource.provider).merge(
-      new_resource.credentials
-    ).to_hash
+    {:provider => new_resource.provider}.merge(new_resource.credentials).to_hash
   )
 end

--- a/recipes/fog.rb
+++ b/recipes/fog.rb
@@ -10,6 +10,5 @@ end
 
 # TODO: Remove this once the gem_hell cookbook is ready to roll
 chef_gem "fog" do
-  version '1.10.1'
   action :install
 end


### PR DESCRIPTION
A working first-pass solution to add Linode support to updating DNS records. Sadly `Record#update` isn't supported, but `Record#save` is hence the extra code.
